### PR TITLE
DAC6-4220 | rules-error and confirmation not dependent on user-answers

### DIFF
--- a/app/controllers/FileConfirmationController.scala
+++ b/app/controllers/FileConfirmationController.scala
@@ -44,7 +44,7 @@ class FileConfirmationController @Inject() (
     extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad(conversationId: String): Action[AnyContent] = (identify).async {
+  def onPageLoad(conversationId: String): Action[AnyContent] = identify.async {
     implicit request =>
       fileDetailsService.getFileDetails(ConversationId(conversationId)) flatMap {
         case Some(fileDetails) =>

--- a/app/controllers/FileConfirmationController.scala
+++ b/app/controllers/FileConfirmationController.scala
@@ -44,7 +44,7 @@ class FileConfirmationController @Inject() (
     extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad(conversationId: String): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+  def onPageLoad(conversationId: String): Action[AnyContent] = (identify).async {
     implicit request =>
       fileDetailsService.getFileDetails(ConversationId(conversationId)) flatMap {
         case Some(fileDetails) =>

--- a/app/controllers/RulesErrorController.scala
+++ b/app/controllers/RulesErrorController.scala
@@ -44,7 +44,7 @@ class RulesErrorController @Inject() (
     with I18nSupport
     with Logging {
 
-  def onPageLoad(conversationId: String): Action[AnyContent] = (identify).async {
+  def onPageLoad(conversationId: String): Action[AnyContent] = identify.async {
     implicit request =>
       fileDetailsService.getFileDetails(ConversationId(conversationId)).map {
         case Some(fileDetails) =>

--- a/app/controllers/RulesErrorController.scala
+++ b/app/controllers/RulesErrorController.scala
@@ -44,7 +44,7 @@ class RulesErrorController @Inject() (
     with I18nSupport
     with Logging {
 
-  def onPageLoad(conversationId: String): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+  def onPageLoad(conversationId: String): Action[AnyContent] = (identify).async {
     implicit request =>
       fileDetailsService.getFileDetails(ConversationId(conversationId)).map {
         case Some(fileDetails) =>


### PR DESCRIPTION
- Rules-error and Confirmation page are no longer dependent on user-answers. I removed all the action builders that require user-answers. This change is to prevent a redirect to journey recovery page when these pages are accessed when the user-answer are not present e.g when they are directly accessed before the IndexController is called.
- 